### PR TITLE
refactor: :truck: Rename to compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,12 +1,10 @@
-version: '3.7'
-
 services:
   api:
     build: .
     depends_on:
       db:
         condition: service_healthy
-    ports: 
+    ports:
       - "3000:3000"
     networks:
       - app_network
@@ -22,9 +20,9 @@ services:
     ports:
       - "3306:3306"
     networks:
-      - app_network  
+      - app_network
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -proot"]
+      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u root -proot" ]
       interval: 10s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
# O que foi feito
- Renomeado o compose para de acordo o novo padrão `compose.yml`
- Removida a tag `version` que está depreciada do compose